### PR TITLE
Replace comment_char with comment_prefix.

### DIFF
--- a/python/pod5/src/pod5/tools/pod5_filter.py
+++ b/python/pod5/src/pod5/tools/pod5_filter.py
@@ -44,7 +44,7 @@ def parse_read_id_targets(ids: Path, output: Path) -> pl.LazyFrame:
         pl.scan_csv(
             ids,
             has_header=False,  # Any header will be filtered out by is_uuid
-            comment_char="#",
+            comment_prefix="#",
             new_columns=[PL_READ_ID],
             rechunk=False,
         )

--- a/python/pod5/src/pod5/tools/pod5_subset.py
+++ b/python/pod5/src/pod5/tools/pod5_subset.py
@@ -121,7 +121,7 @@ def parse_table_mapping(
             summary_path,
             columns=columns,
             separator=get_separator(summary_path),
-            comment_char="#",
+            comment_prefix="#",
         )
         .lazy()
         .with_columns(


### PR DESCRIPTION
Sometime between `polars` v0.18 and v0.19 the `comment_char` keyword argument to `pl.read_csv` was depreciated in favor of `comment_prefix`. This PR replaces the two instances of `comment_char` and should resolve [Issue 142](https://github.com/nanoporetech/pod5-file-format/issues/142).