### PR TITLE
add stdexcept include to thread_pool.cpp to fix compilation

### DIFF
--- a/c++/pod5_format/thread_pool.cpp
+++ b/c++/pod5_format/thread_pool.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 
 namespace pod5 {
 


### PR DESCRIPTION
building fails due to std::logic_error not being found without the stdexcept include:
```
[  3%] Building CXX object c++/CMakeFiles/pod5_format.dir/pod5_format/thread_pool.cpp.o
pod5-file-format/c++/pod5_format/thread_pool.cpp: In member function ‘virtual void pod5::{anonymous}::ThreadPoolImpl::post(std::function<void()>)’:
pod5-file-format/c++/pod5_format/thread_pool.cpp:84:28: error: ‘logic_error’ is not a member of ‘std’
   84 |                 throw std::logic_error{"ThreadPool: post() called after stop_and_drain()"};
      |                            ^~~~~~~~~~~
pod5-file-format/c++/pod5_format/thread_pool.cpp:10:1: note: ‘std::logic_error’ is defined in header ‘<stdexcept>’; this is probably fixable by adding ‘#include <stdexcept>’
    9 | #include <thread>
  +++ |+#include <stdexcept>
   10 | #include <vector>
```

this pull request adds the include, fixing the build error.